### PR TITLE
Get cloud formation resource type from modules.yaml (resource)

### DIFF
--- a/changelogs/fragments/cloud_content_generate_ignore_files_action_plugin.yaml
+++ b/changelogs/fragments/cloud_content_generate_ignore_files_action_plugin.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - convert refresh_ignore_files.py python script to action plugin.

--- a/changelogs/fragments/cloud_content_resource_type_input.yaml
+++ b/changelogs/fragments/cloud_content_resource_type_input.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Get cloud formation resource type from modules.yaml.

--- a/plugins/action/generate_cloud_schema.py
+++ b/plugins/action/generate_cloud_schema.py
@@ -77,14 +77,16 @@ class ActionModule(ActionBase):
         self._task_vars = task_vars
         
         args = self._task.args
-        RESOURCES = []
         resource_file = pathlib.Path(args.get("resource") + "/modules.yaml")
         res = resource_file.read_text()
-        for i in yaml.safe_load(res):
-            RESOURCES = i.get("RESOURCES", "")
-            if RESOURCES:
-                break
-        for type_name in RESOURCES:
+
+        RESOURCES = yaml.load(
+            pathlib.Path(resource_file).read_text(), Loader=yaml.FullLoader
+        )
+
+        for module in RESOURCES:
+            for k, v in module.items():
+                type_name = v["resource"]
             print("Collecting Schema")
             print(type_name)
             cloudformation = generator.CloudFormationWrapper(boto3.client("cloudformation"))

--- a/roles/module_openapi_cloud/tasks/main.yaml
+++ b/roles/module_openapi_cloud/tasks/main.yaml
@@ -24,10 +24,8 @@
   when: ( plugin['action'] == 'generate_examples' ) or ( plugin['action'] == 'generate_all' )
 
 - name: Generate ignore files for "{{ collection['name'] }}"
-  ansible.builtin.command: python3 "{{ role_path }}"/templates/refresh_ignore_files.py
-    --target-dir "{{ collection['path'] }}"
-  delegate_to: 127.0.0.1
-  run_once: true
+  ansible.content_builder.generate_cloud_ignore_files:
+      target_dir: "{{ collection['path'] }}"
   changed_when: false
   when:
       - ( plugin['action'] == 'generate_ignore_files' ) or ( plugin['action'] == 'generate_all' )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Get cloud formation resource type from modules.yaml (resource) to have a single input file for [generate_cloud_schema.py](https://github.com/ansible-community/ansible.content_builder/blob/cloud_content/plugins/action/generate_cloud_schema.py) and [generate_cloud_modules.py](https://github.com/ansible-community/ansible.content_builder/blob/cloud_content/plugins/action/generate_cloud_modules.py) action plugins.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
