### PR TITLE
Do not fail when plugin content is undefined

### DIFF
--- a/changelogs/fragments/traceback.yaml
+++ b/changelogs/fragments/traceback.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Do not fail if plugin content type is undefined.

--- a/roles/scaffold_plugins/tasks/template.yml
+++ b/roles/scaffold_plugins/tasks/template.yml
@@ -4,7 +4,7 @@
     msg: "Scaffolding {{ plugin['name'] }} of type {{ plugin['type'] }}"
 
 - name: Scaffold plugin
-  when: plugin['content'] != 'cloud'
+  when: plugin['content']|d("") != 'cloud'
   block:
     - name: Set path to main plugin file for generic plugins
       ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY
Fixes the following traceback:

```
TASK [ansible.content_builder.scaffold_plugins : Set path to main plugin file for generic plugins] ***

fatal: [localhost]: FAILED! => {"msg": "The conditional check 'plugin['content'] != 'cloud'' failed. The error was: error while evaluating conditional (plugin['content'] != 'cloud'): 'dict object' has no attribute 'content'. 'dict object' has no attribute 'content'\n\nThe error appears to be in '/root/.ansible/collections/ansible_collections/ansible/content_builder/roles/scaffold_plugins/tasks/template.yml': line 9, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  block:\n    - name: Set path to main plugin file for generic plugins\n      ^ here\n"}
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
