### PR TITLE
amazon.cloud: acl_name should be camelcased as ACLName

### DIFF
--- a/roles/module_openapi_cloud/templates/module_directory/amazon_cloud/default_module.j2
+++ b/roles/module_openapi_cloud/templates/module_directory/amazon_cloud/default_module.j2
@@ -39,6 +39,8 @@ def main():
         )
 
     params_to_set = snake_dict_to_camel_dict(_params_to_set, capitalize_first=True)
+    if "AclName" in params_to_set:
+        params_to_set["ACLName"] = params_to_set.pop("AclName")
 
     # Ignore createOnlyProperties that can be set only during resource creation
     create_only_params = {{create_only_properties}}


### PR DESCRIPTION
The `acl_name` from MemoryDB is a special case, the whole ACL acronym should be upper-case.

See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-memorydb-cluster.html#cfn-memorydb-cluster-aclname
