### PR TITLE
vmware: Add pylint disable to skip unused imports 

### DIFF
--- a/roles/module_openapi_cloud/templates/module_directory/vmware_rest/header.j2
+++ b/roles/module_openapi_cloud/templates/module_directory/vmware_rest/header.j2
@@ -18,8 +18,8 @@ RETURN = r"""
 # This structure describes the format of the data expected by the end-points
 PAYLOAD_FORMAT = {{payload_format}}  # pylint: disable=line-too-long
 
-import json
-import socket
+import json  # pylint: disable=unused-import
+import socket  # pylint: disable=unused-import
 from ansible.module_utils.basic import env_fallback
 try:
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import EmbeddedModuleFailure
@@ -27,6 +27,8 @@ try:
     AnsibleModule.collection_name = "vmware.vmware_rest"
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
+
+# pylint: disable=unused-import
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Some of the vmware module files throw sanity errors because of unused imports. This PR disables pylint unused import checks on the lines in the template file.

Errors seen here - https://github.com/ansible-collections/vmware.vmware_rest/actions/runs/4852914889/jobs/8648491794

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
