### PR TITLE
generate_cloud_modules - keep non-plugins entries when generating sanity ignore files

### DIFF
--- a/changelogs/fragments/61-multiple-fixes.yml
+++ b/changelogs/fragments/61-multiple-fixes.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - generate_cloud_modules should keep entries for files not part of plugins/* when generating tests/sanity/ignore-*.txt files.

--- a/plugins/action/generate_cloud_modules.py
+++ b/plugins/action/generate_cloud_modules.py
@@ -1219,6 +1219,13 @@ def generate_amazon_cloud(args: Iterable, role_path: str):
             )
 
         ignore_file = ignore_dir / f"ignore-{version}.txt"
+
+        # keep all non-plugins entries from ignore file
+        if ignore_file.exists():
+            for line in ignore_file.read_text().split("\n"):
+                if not line.startswith("plugins/"):
+                    per_version_ignore_content += line + "\n"
+
         ignore_file.write_text(per_version_ignore_content)
 
     meta_dir = pathlib.Path(args.get("target_dir") + "/meta")


### PR DESCRIPTION
##### SUMMARY

Currently when using the generator, `generate_cloud_modules` cleans everything from `tests/sanity/ignore-*.txt` files, 
This fix aims to solve, for instance, if there is an entry like `tests/integration/targets/xxx/xxx` this will be saved to be part of the newly generated content.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
