### PR TITLE
Fix role vars name in the plugin

### DIFF
--- a/changelogs/fragments/role_vars_name_reference_fix.yaml
+++ b/changelogs/fragments/role_vars_name_reference_fix.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Change variable names that are used in the plugin files to match the ones in vars file."

--- a/plugins/action/generate_cloud_examples.py
+++ b/plugins/action/generate_cloud_examples.py
@@ -276,7 +276,7 @@ class ActionModule(ActionBase):
         tasks = []
         test_scenarios_dirs = [
             Path(args.get("target_dir")) / Path(i)
-            for i in vars["examples"][collection_name]["load_from"]
+            for i in vars["module_openapi_cloud__examples"][collection_name]["load_from"]
         ]
         for scenario_dir in test_scenarios_dirs:
             if not scenario_dir.is_dir():
@@ -289,8 +289,8 @@ class ActionModule(ActionBase):
         extracted_examples = extract(
             tasks,
             collection_name,
-            dont_look_up_vars=vars["examples"][collection_name]["dont_look_up_vars"],
-            task_selector=vars["examples"][collection_name]["task_selector"],
+            dont_look_up_vars=vars["module_openapi_cloud__examples"][collection_name]["dont_look_up_vars"],
+            task_selector=vars["module_openapi_cloud__examples"][collection_name]["task_selector"],
         )
         inject(Path(args.get("target_dir")), extracted_examples)
         return self._result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

[PR](https://github.com/ansible-community/ansible.content_builder/pull/63)  fixed ansible-lint issues by changing the var names used in the roles. Some references were missed in the cloud plugin. Those var name references are changed by this PR.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
