### PR TITLE
vmware_rest: vSphere requirements 7.0.3

### DIFF
--- a/changelogs/fragments/vmware_rest-vsphere-requirements.yaml
+++ b/changelogs/fragments/vmware_rest-vsphere-requirements.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Update the vSphere requirements for generated vmware.vmware_rest modules (https://github.com/ansible-community/ansible.content_builder/pull/73)."

--- a/plugins/action/generate_cloud_modules.py
+++ b/plugins/action/generate_cloud_modules.py
@@ -208,7 +208,7 @@ def gen_documentation(
         "author": ["Ansible Cloud Team (@ansible-collections)"],
         "description": description,
         "module": name,
-        "notes": ["Tested on vSphere 7.0.2"],
+        "notes": ["Tested on vSphere 7.0.3"],
         "options": {
             "vcenter_hostname": {
                 "description": [
@@ -262,7 +262,7 @@ def gen_documentation(
                 "version_added": "2.1.0",
             },
         },
-        "requirements": ["vSphere 7.0.2 or greater", "python >= 3.6", "aiohttp"],
+        "requirements": ["vSphere 7.0.3 or greater", "python >= 3.6", "aiohttp"],
         "short_description": short_description,
         "version_added": next_version,
     }


### PR DESCRIPTION
##### SUMMARY
vmware.vmware_rest CI uses vSphere 7.0.3, so we should document this when creating the modules.

In the long run, it would be helpful if this could be configured in the MANIFEST.yaml.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/action/generate_cloud_modules.py

##### ADDITIONAL INFORMATION
ansible-collections/vmware.vmware_rest#450

cc @alinabuzachis 