### PR TITLE
Update `ansible-lint` and `requires_ansible` versions

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.13.0'
+requires_ansible: '>=2.17.0'

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands = -flake8 --select C90 --max-complexity 10 --format=html --htmldir={pos
 
 [testenv:ansible-lint]
 deps =
-  ansible-lint==6.17.2
+  ansible-lint>=25.1.2
 changedir = {toxinidir}
 commands = 
   ansible-lint


### PR DESCRIPTION
Updating `ansible-lint` version to minimum of `25.1.2` and `requires_ansible` to minimum of `2.17.0`